### PR TITLE
Schiessergebnisse Beispielanwendung

### DIFF
--- a/shooting-app/README.md
+++ b/shooting-app/README.md
@@ -1,0 +1,9 @@
+# Schießergebnisse Webanwendung
+
+Dies ist eine vereinfachte Beispielimplementierung einer Anwendung zur Anzeige und Verwaltung von Schießergebnissen. Sie besteht aus einem Node.js-Backend und zwei React-Frontends (Admin und Zuschauer).
+
+* Backend: `backend` (Express, XML-Import)
+* Admin-Frontend: `frontend/admin` (React/TypeScript)
+* Zuschauer-Frontend: `frontend/viewer` (React/TypeScript)
+
+Alle Texte sind auf Deutsch gehalten. Die React-Komponenten zeigen lediglich die geladenen XML-Daten an und können als Ausgangsbasis für eine vollständige Umsetzung dienen.

--- a/shooting-app/README.md
+++ b/shooting-app/README.md
@@ -7,3 +7,31 @@ Dies ist eine vereinfachte Beispielimplementierung einer Anwendung zur Anzeige u
 * Zuschauer-Frontend: `frontend/viewer` (React/TypeScript)
 
 Alle Texte sind auf Deutsch gehalten. Die React-Komponenten zeigen lediglich die geladenen XML-Daten an und können als Ausgangsbasis für eine vollständige Umsetzung dienen.
+
+## Schnellstart
+
+1. Backend starten:
+
+   ```bash
+   cd shooting-app/backend
+   npm install
+   npm start
+   ```
+
+2. Admin-Frontend starten:
+
+   ```bash
+   cd shooting-app/frontend/admin
+   npm install
+   npm start
+   ```
+
+3. Zuschauer-Frontend starten:
+
+   ```bash
+   cd shooting-app/frontend/viewer
+   npm install
+   npm start
+   ```
+
+Alle Anwendungen laufen lokal (“Admin” auf http://localhost:5173, “Zuschauer” auf einem zweiten Port). Das Backend stellt die API auf Port 3001 bereit.

--- a/shooting-app/backend/README.md
+++ b/shooting-app/backend/README.md
@@ -1,6 +1,8 @@
 # Shooting Backend (Schießergebnisse)
 
 Ein einfacher Express-Server zur Verwaltung und zum Import von DISAG-XML-Daten.
+Im Ordner `data` liegt eine Beispiel-XML (`results.xml`). Beim Start wird diese
+Datei eingelesen und über die REST-Schnittstelle bereitgestellt.
 
 ## Starten
 

--- a/shooting-app/backend/README.md
+++ b/shooting-app/backend/README.md
@@ -1,0 +1,12 @@
+# Shooting Backend (Schießergebnisse)
+
+Ein einfacher Express-Server zur Verwaltung und zum Import von DISAG-XML-Daten.
+
+## Starten
+
+```bash
+npm install
+npm start
+```
+
+Der Server läuft standardmäßig auf Port **3001** und lädt die XML-Datei aus `config.json`.

--- a/shooting-app/backend/config.json
+++ b/shooting-app/backend/config.json
@@ -1,0 +1,4 @@
+{
+  "xmlPath": "./data/results.xml",
+  "interval": 5000
+}

--- a/shooting-app/backend/data/results.xml
+++ b/shooting-app/backend/data/results.xml
@@ -1,0 +1,10 @@
+<results>
+  <shooter>
+    <name>Max Mustermann</name>
+    <score>95</score>
+  </shooter>
+  <shooter>
+    <name>Anna Beispiel</name>
+    <score>92</score>
+  </shooter>
+</results>

--- a/shooting-app/backend/package.json
+++ b/shooting-app/backend/package.json
@@ -1,0 +1,15 @@
+{
+  "name": "shooting-backend",
+  "version": "1.0.0",
+  "type": "module",
+  "description": "Backend fuer Schießergebnisse",
+  "main": "server.js",
+  "scripts": {
+    "start": "node server.js"
+  },
+  "dependencies": {
+    "express": "^4.18.2",
+    "xml2js": "^0.4.23",
+    "cors": "^2.8.5"
+  }
+}

--- a/shooting-app/backend/server.js
+++ b/shooting-app/backend/server.js
@@ -1,0 +1,66 @@
+import express from 'express';
+import fs from 'fs';
+import {parseStringPromise} from 'xml2js';
+import cors from 'cors';
+
+const app = express();
+app.use(express.json());
+app.use(cors());
+
+let config = { xmlPath: './data/results.xml', interval: 5000 };
+
+try {
+  const data = fs.readFileSync('./config.json', 'utf8');
+  config = JSON.parse(data);
+} catch (e) {
+  fs.writeFileSync('./config.json', JSON.stringify(config, null, 2));
+}
+
+let scores = [];
+async function importXml() {
+  try {
+    const xml = fs.readFileSync(config.xmlPath, 'utf8');
+    const result = await parseStringPromise(xml);
+    scores = result; // hier koennte eine genauere Verarbeitung erfolgen
+    console.log('XML importiert:', new Date());
+  } catch (err) {
+    console.error('Fehler beim Import:', err.message);
+  }
+}
+
+app.post('/login', (req, res) => {
+  const {user, pass} = req.body;
+  // Dummy-Login
+  if (user === 'admin' && pass === 'admin') {
+    res.json({role: 'admin'});
+  } else if (user === 'auswerter') {
+    res.json({role: 'auswerter'});
+  } else {
+    res.json({role: 'betrachter'});
+  }
+});
+
+app.get('/scores', (req, res) => {
+  res.json(scores);
+});
+
+app.post('/config/xml-path', (req, res) => {
+  const {path} = req.body;
+  if (path) {
+    config.xmlPath = path;
+    fs.writeFileSync('./config.json', JSON.stringify(config, null, 2));
+    res.json({ok: true});
+  } else {
+    res.status(400).json({error: 'Pfad fehlt'});
+  }
+});
+
+app.post('/import', async (req, res) => {
+  await importXml();
+  res.json({ok: true});
+});
+
+setInterval(importXml, config.interval);
+importXml();
+
+app.listen(3001, () => console.log('Server laeuft auf Port 3001'));

--- a/shooting-app/backend/server.js
+++ b/shooting-app/backend/server.js
@@ -1,6 +1,6 @@
 import express from 'express';
 import fs from 'fs';
-import {parseStringPromise} from 'xml2js';
+import { parseStringPromise } from 'xml2js';
 import cors from 'cors';
 
 const app = express();
@@ -21,7 +21,10 @@ async function importXml() {
   try {
     const xml = fs.readFileSync(config.xmlPath, 'utf8');
     const result = await parseStringPromise(xml);
-    scores = result; // hier koennte eine genauere Verarbeitung erfolgen
+    scores = (result.results.shooter || []).map((s) => ({
+      name: s.name[0],
+      score: parseInt(s.score[0], 10) || 0,
+    }));
     console.log('XML importiert:', new Date());
   } catch (err) {
     console.error('Fehler beim Import:', err.message);
@@ -41,7 +44,8 @@ app.post('/login', (req, res) => {
 });
 
 app.get('/scores', (req, res) => {
-  res.json(scores);
+  const sorted = [...scores].sort((a, b) => b.score - a.score);
+  res.json(sorted);
 });
 
 app.post('/config/xml-path', (req, res) => {

--- a/shooting-app/frontend/admin/index.html
+++ b/shooting-app/frontend/admin/index.html
@@ -1,0 +1,12 @@
+<!DOCTYPE html>
+<html lang="de">
+<head>
+  <meta charset="UTF-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+  <title>Schießergebnisse Admin</title>
+  <script type="module" src="/src/index.tsx"></script>
+</head>
+<body class="bg-gray-900 text-white">
+  <div id="root"></div>
+</body>
+</html>

--- a/shooting-app/frontend/admin/package.json
+++ b/shooting-app/frontend/admin/package.json
@@ -1,0 +1,22 @@
+{
+  "name": "shooting-admin",
+  "version": "1.0.0",
+  "private": true,
+  "scripts": {
+    "start": "vite",
+    "build": "vite build"
+  },
+  "dependencies": {
+    "react": "^18.2.0",
+    "react-dom": "^18.2.0"
+  },
+  "devDependencies": {
+    "typescript": "^5.2.2",
+    "vite": "^5.0.0",
+    "@types/react": "^18.2.0",
+    "@types/react-dom": "^18.2.0",
+    "tailwindcss": "^3.3.0",
+    "postcss": "^8.4.0",
+    "autoprefixer": "^10.4.0"
+  }
+}

--- a/shooting-app/frontend/admin/postcss.config.js
+++ b/shooting-app/frontend/admin/postcss.config.js
@@ -1,0 +1,6 @@
+module.exports = {
+  plugins: {
+    tailwindcss: {},
+    autoprefixer: {},
+  },
+};

--- a/shooting-app/frontend/admin/src/App.tsx
+++ b/shooting-app/frontend/admin/src/App.tsx
@@ -1,0 +1,25 @@
+import React, { useEffect, useState } from 'react';
+
+interface ScoreEntry {
+  // hier könnte eine genauere Typisierung erfolgen
+  [key: string]: any;
+}
+
+export default function App() {
+  const [scores, setScores] = useState<ScoreEntry[]>([]);
+
+  useEffect(() => {
+    fetch('http://localhost:3001/scores')
+      .then(res => res.json())
+      .then(setScores);
+  }, []);
+
+  return (
+    <div className="p-4">
+      <h1 className="text-2xl font-bold mb-4">Live-Ergebnisse</h1>
+      <pre className="bg-gray-800 p-2 rounded">
+        {JSON.stringify(scores, null, 2)}
+      </pre>
+    </div>
+  );
+}

--- a/shooting-app/frontend/admin/src/App.tsx
+++ b/shooting-app/frontend/admin/src/App.tsx
@@ -7,19 +7,84 @@ interface ScoreEntry {
 
 export default function App() {
   const [scores, setScores] = useState<ScoreEntry[]>([]);
+  const [user, setUser] = useState('');
+  const [pass, setPass] = useState('');
+  const [role, setRole] = useState('');
+
+  const login = () => {
+    fetch('http://localhost:3001/login', {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify({ user, pass }),
+    })
+      .then((res) => res.json())
+      .then((data) => setRole(data.role));
+  };
+
+  const loadScores = () => {
+    fetch('http://localhost:3001/scores')
+      .then((res) => res.json())
+      .then(setScores);
+  };
 
   useEffect(() => {
-    fetch('http://localhost:3001/scores')
-      .then(res => res.json())
-      .then(setScores);
-  }, []);
+    if (role) {
+      loadScores();
+    }
+  }, [role]);
 
   return (
     <div className="p-4">
-      <h1 className="text-2xl font-bold mb-4">Live-Ergebnisse</h1>
-      <pre className="bg-gray-800 p-2 rounded">
-        {JSON.stringify(scores, null, 2)}
-      </pre>
+      {!role ? (
+        <div className="max-w-sm mx-auto space-y-2">
+          <h1 className="text-xl font-bold mb-2">Login</h1>
+          <input
+            className="w-full p-2 rounded text-black"
+            placeholder="Benutzer"
+            value={user}
+            onChange={(e) => setUser(e.target.value)}
+          />
+          <input
+            className="w-full p-2 rounded text-black"
+            type="password"
+            placeholder="Passwort"
+            value={pass}
+            onChange={(e) => setPass(e.target.value)}
+          />
+          <button
+            className="bg-blue-600 px-3 py-2 rounded"
+            onClick={login}
+          >
+            Anmelden
+          </button>
+        </div>
+      ) : (
+        <div>
+          <h1 className="text-2xl font-bold mb-4">Live-Ergebnisse ({role})</h1>
+          <button
+            className="mb-2 bg-blue-600 px-3 py-2 rounded"
+            onClick={loadScores}
+          >
+            Aktualisieren
+          </button>
+          <table className="min-w-full bg-gray-800 rounded">
+            <thead>
+              <tr>
+                <th className="px-2 py-1 text-left">Schütze</th>
+                <th className="px-2 py-1 text-right">Punkte</th>
+              </tr>
+            </thead>
+            <tbody>
+              {scores.map((s, i) => (
+                <tr key={i} className="odd:bg-gray-700">
+                  <td className="px-2 py-1">{s.name}</td>
+                  <td className="px-2 py-1 text-right">{s.score}</td>
+                </tr>
+              ))}
+            </tbody>
+          </table>
+        </div>
+      )
     </div>
   );
 }

--- a/shooting-app/frontend/admin/src/index.css
+++ b/shooting-app/frontend/admin/src/index.css
@@ -1,0 +1,3 @@
+@tailwind base;
+@tailwind components;
+@tailwind utilities;

--- a/shooting-app/frontend/admin/src/index.tsx
+++ b/shooting-app/frontend/admin/src/index.tsx
@@ -1,0 +1,7 @@
+import React from 'react';
+import { createRoot } from 'react-dom/client';
+import App from './App';
+import './index.css';
+
+const root = createRoot(document.getElementById('root')!);
+root.render(<App />);

--- a/shooting-app/frontend/admin/tailwind.config.js
+++ b/shooting-app/frontend/admin/tailwind.config.js
@@ -1,0 +1,7 @@
+module.exports = {
+  content: ['./index.html', './src/**/*.{ts,tsx}'],
+  theme: {
+    extend: {},
+  },
+  plugins: [],
+};

--- a/shooting-app/frontend/admin/tsconfig.json
+++ b/shooting-app/frontend/admin/tsconfig.json
@@ -1,0 +1,11 @@
+{
+  "compilerOptions": {
+    "target": "esnext",
+    "module": "esnext",
+    "jsx": "react-jsx",
+    "strict": true,
+    "esModuleInterop": true,
+    "skipLibCheck": true,
+    "forceConsistentCasingInFileNames": true
+  }
+}

--- a/shooting-app/frontend/viewer/index.html
+++ b/shooting-app/frontend/viewer/index.html
@@ -1,0 +1,12 @@
+<!DOCTYPE html>
+<html lang="de">
+<head>
+  <meta charset="UTF-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+  <title>Schießergebnisse Zuschauer</title>
+  <script type="module" src="/src/index.tsx"></script>
+</head>
+<body class="bg-gray-900 text-white">
+  <div id="root"></div>
+</body>
+</html>

--- a/shooting-app/frontend/viewer/package.json
+++ b/shooting-app/frontend/viewer/package.json
@@ -1,0 +1,22 @@
+{
+  "name": "shooting-viewer",
+  "version": "1.0.0",
+  "private": true,
+  "scripts": {
+    "start": "vite",
+    "build": "vite build"
+  },
+  "dependencies": {
+    "react": "^18.2.0",
+    "react-dom": "^18.2.0"
+  },
+  "devDependencies": {
+    "typescript": "^5.2.2",
+    "vite": "^5.0.0",
+    "@types/react": "^18.2.0",
+    "@types/react-dom": "^18.2.0",
+    "tailwindcss": "^3.3.0",
+    "postcss": "^8.4.0",
+    "autoprefixer": "^10.4.0"
+  }
+}

--- a/shooting-app/frontend/viewer/postcss.config.js
+++ b/shooting-app/frontend/viewer/postcss.config.js
@@ -1,0 +1,6 @@
+module.exports = {
+  plugins: {
+    tailwindcss: {},
+    autoprefixer: {},
+  },
+};

--- a/shooting-app/frontend/viewer/src/App.tsx
+++ b/shooting-app/frontend/viewer/src/App.tsx
@@ -8,20 +8,34 @@ export default function App() {
   const [scores, setScores] = useState<ScoreEntry[]>([]);
 
   useEffect(() => {
-    const interval = setInterval(() => {
+    const load = () =>
       fetch('http://localhost:3001/scores')
-        .then(res => res.json())
+        .then((res) => res.json())
         .then(setScores);
-    }, 5000);
+    load();
+    const interval = setInterval(load, 5000);
     return () => clearInterval(interval);
   }, []);
 
   return (
     <div className="p-4">
       <h1 className="text-2xl font-bold mb-4">Rangliste</h1>
-      <pre className="bg-gray-800 p-2 rounded">
-        {JSON.stringify(scores, null, 2)}
-      </pre>
+      <table className="min-w-full bg-gray-800 rounded">
+        <thead>
+          <tr>
+            <th className="px-2 py-1 text-left">Schütze</th>
+            <th className="px-2 py-1 text-right">Punkte</th>
+          </tr>
+        </thead>
+        <tbody>
+          {scores.map((s, i) => (
+            <tr key={i} className="odd:bg-gray-700">
+              <td className="px-2 py-1">{s.name}</td>
+              <td className="px-2 py-1 text-right">{s.score}</td>
+            </tr>
+          ))}
+        </tbody>
+      </table>
     </div>
   );
 }

--- a/shooting-app/frontend/viewer/src/App.tsx
+++ b/shooting-app/frontend/viewer/src/App.tsx
@@ -1,0 +1,27 @@
+import React, { useEffect, useState } from 'react';
+
+interface ScoreEntry {
+  [key: string]: any;
+}
+
+export default function App() {
+  const [scores, setScores] = useState<ScoreEntry[]>([]);
+
+  useEffect(() => {
+    const interval = setInterval(() => {
+      fetch('http://localhost:3001/scores')
+        .then(res => res.json())
+        .then(setScores);
+    }, 5000);
+    return () => clearInterval(interval);
+  }, []);
+
+  return (
+    <div className="p-4">
+      <h1 className="text-2xl font-bold mb-4">Rangliste</h1>
+      <pre className="bg-gray-800 p-2 rounded">
+        {JSON.stringify(scores, null, 2)}
+      </pre>
+    </div>
+  );
+}

--- a/shooting-app/frontend/viewer/src/index.css
+++ b/shooting-app/frontend/viewer/src/index.css
@@ -1,0 +1,3 @@
+@tailwind base;
+@tailwind components;
+@tailwind utilities;

--- a/shooting-app/frontend/viewer/src/index.tsx
+++ b/shooting-app/frontend/viewer/src/index.tsx
@@ -1,0 +1,7 @@
+import React from 'react';
+import { createRoot } from 'react-dom/client';
+import App from './App';
+import './index.css';
+
+const root = createRoot(document.getElementById('root')!);
+root.render(<App />);

--- a/shooting-app/frontend/viewer/tailwind.config.js
+++ b/shooting-app/frontend/viewer/tailwind.config.js
@@ -1,0 +1,7 @@
+module.exports = {
+  content: ['./index.html', './src/**/*.{ts,tsx}'],
+  theme: {
+    extend: {},
+  },
+  plugins: [],
+};

--- a/shooting-app/frontend/viewer/tsconfig.json
+++ b/shooting-app/frontend/viewer/tsconfig.json
@@ -1,0 +1,11 @@
+{
+  "compilerOptions": {
+    "target": "esnext",
+    "module": "esnext",
+    "jsx": "react-jsx",
+    "strict": true,
+    "esModuleInterop": true,
+    "skipLibCheck": true,
+    "forceConsistentCasingInFileNames": true
+  }
+}


### PR DESCRIPTION
## Zusammenfassung
- Beispiel-App fuer Schießergebnisse im Ordner `shooting-app`
- Einfaches Express-Backend mit XML-Import
- Zwei React-Frontends (Admin und Zuschauer) mit Tailwind

## Testanweisungen
- keine automatischen Tests vorhanden

------
https://chatgpt.com/codex/tasks/task_e_686e3b834f34832c803ab8aa8a2618f7